### PR TITLE
update to support darwin/arm64

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -22,6 +22,7 @@ builds:
       - darwin
     goarch:
       - amd64
+      - arm64
     binary: "{{ .ProjectName }}_{{ .Version }}"
 archives:
   - format: zip

--- a/Makefile
+++ b/Makefile
@@ -13,6 +13,7 @@ build:
 	go build -o ./dist/${BINARY}
 
 release:
+	GOOS=darwin GOARCH=arm64 go build -o ./bin/${BINARY}_${VERSION}_darwin_arm64
 	GOOS=darwin GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_darwin_amd64
 	GOOS=freebsd GOARCH=386 go build -o ./bin/${BINARY}_${VERSION}_freebsd_386
 	GOOS=freebsd GOARCH=amd64 go build -o ./bin/${BINARY}_${VERSION}_freebsd_amd64


### PR DESCRIPTION
- Installing on M1 mac currently results in:
<img width="1479" alt="image" src="https://user-images.githubusercontent.com/42123115/226752963-f8ccb029-8317-4ef7-b71e-a855ac146e41.png">

- This PR adds support for darwin/arm64, updating any places where explicit architectures are described.

Please provide additional guidance if other things need to be updated to properly support the platform. Thanks!